### PR TITLE
Ignore invalid paths

### DIFF
--- a/src/Assetic/SourceMapFilter.php
+++ b/src/Assetic/SourceMapFilter.php
@@ -164,14 +164,18 @@ class SourceMapFilter implements FilterInterface, HashableInterface
 
             // remove the first part of the path - what's left should be relative to the root project directory
             $source = preg_replace("#^{$this->sourceMapSourcePathTrim}#", '', $source);
-            
-            $source = Utils\removeRelPathComponents($source);
-            $source = ltrim($source, '/');
-            
-            return $source;
+
+
+            try {
+                $source = Utils\removeRelPathComponents($source);
+                $source = ltrim($source, '/');
+                return $source;
+            } catch (\Exception $e) {
+                return null;
+            }
         }, $sourceMap['sources']);
 
-        $sourceMap['sources'] = array_values($sourceMap['sources']);
+        $sourceMap['sources'] = array_values(array_filter($sourceMap['sources']));
 
         // save the source map to the sym-assets folder
         $to = $this->asseticWriteToDir . '/' . $targetPathForSourceMap;

--- a/src/Assetic/SourceMapFilter.php
+++ b/src/Assetic/SourceMapFilter.php
@@ -153,6 +153,7 @@ class SourceMapFilter implements FilterInterface, HashableInterface
         // the 'sources' property is what dev tools (such as Chrome DevTools) display as the filename for the original source
         // transform tmp file names back to original file name
         $sourceMap['sources'] = array_map(function ($source) use ($tmpInputToAssetMap) {
+
             if (array_key_exists($source, $tmpInputToAssetMap)) {
                 $asset = $tmpInputToAssetMap[$source];
                 if ($asset instanceof HttpAsset) {
@@ -161,21 +162,19 @@ class SourceMapFilter implements FilterInterface, HashableInterface
 
                 $source = $asset->getSourceRoot() . '/' . $asset->getSourcePath();
             }
-
             // remove the first part of the path - what's left should be relative to the root project directory
             $source = preg_replace("#^{$this->sourceMapSourcePathTrim}#", '', $source);
 
-
             try {
                 $source = Utils\removeRelPathComponents($source);
-                $source = ltrim($source, '/');
-                return $source;
             } catch (\Exception $e) {
-                return null;
+                // relative paths above the root are ok here
             }
+            $source = ltrim($source, '/');
+            return $source;
         }, $sourceMap['sources']);
 
-        $sourceMap['sources'] = array_values(array_filter($sourceMap['sources']));
+        $sourceMap['sources'] = array_values($sourceMap['sources']);
 
         // save the source map to the sym-assets folder
         $to = $this->asseticWriteToDir . '/' . $targetPathForSourceMap;

--- a/tests/SourceMapFilterTest.php
+++ b/tests/SourceMapFilterTest.php
@@ -45,66 +45,66 @@ class SourceMapFilterTest extends TestCase
         $sourceMap = $this->loadSourceMap("$asseticWriteTo/asset.js.map");
         $this->assertEquals($this->loadSourceMap('tests/simple/expected.js.map'), $sourceMap);
     }
-//
-//    public function testSourceMapFilterComplex()
-//    {
-//        $asseticWriteTo = sys_get_temp_dir();
-//        $worker = new FlattenWorker([
-//            [
-//                'match' => '/\.js$/',
-//                'class' => SourceMapFilter::class,
-//                'args' => [[
-//                    'site_url' => 'www.coursehero.com/sym-assets',
-//                    'assetic_write_to' => $asseticWriteTo,
-//                    'source_map_source_path_trim' => dirname(__DIR__)
-//                ]]
-//            ]
-//        ]);
-//
-//        $factory = $this->createMock(AssetFactory::class);
-//
-//        $collection = new AssetCollection();
-//        $collection->setTargetPath('expected.js');
-//        $collection->add($this->makeStringAsset(__DIR__ . '/complex', 'asset1.js'));
-//        $collection->add(new FileAsset(__DIR__ . '/complex/test.js'));
-//        $collection->add(new HttpAsset('https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.js'));
-//        $collection = $worker->process($collection, $factory);
-//
-//        $this->assertEquals(file_get_contents('tests/complex/expected.js'), $collection->dump());
-//
-//        $sourceMap = $this->loadSourceMap("$asseticWriteTo/expected.js.map");
-//        $this->assertEquals($this->loadSourceMap('tests/complex/expected.js.map'), $sourceMap);
-//    }
-//
-//    // uglifyjs can use an input file's source map, if provided inline
-//    public function testSourceMapFilterComposedSourceMap()
-//    {
-//        $asseticWriteTo = sys_get_temp_dir();
-//        $worker = new FlattenWorker([
-//            [
-//                'match' => '/\.js$/',
-//                'class' => SourceMapFilter::class,
-//                'args' => [[
-//                    'site_url' => 'www.coursehero.com/sym-assets',
-//                    'assetic_write_to' => $asseticWriteTo,
-//                    'source_map_source_path_trim' => dirname(__DIR__)
-//                ]]
-//            ]
-//        ]);
-//
-//        $factory = $this->createMock(AssetFactory::class);
-//
-//        $collection = new AssetCollection();
-//        $collection->setTargetPath('composed.js');
-//        $collection->add($this->makeStringAsset(__DIR__ . '/composed', 'asset1.js'));
-//        $collection->add(new FileAsset(dirname(__FILE__) . '/composed/ts.js'));
-//        $collection = $worker->process($collection, $factory);
-//
-//        $this->assertEquals(file_get_contents('tests/composed/expected.js'), $collection->dump());
-//
-//        $sourceMap = $this->loadSourceMap("$asseticWriteTo/composed.js.map");
-//        $this->assertEquals($this->loadSourceMap('tests/composed/expected.js.map'), $sourceMap);
-//    }
+
+    public function testSourceMapFilterComplex()
+    {
+        $asseticWriteTo = sys_get_temp_dir();
+        $worker = new FlattenWorker([
+            [
+                'match' => '/\.js$/',
+                'class' => SourceMapFilter::class,
+                'args' => [[
+                    'site_url' => 'www.coursehero.com/sym-assets',
+                    'assetic_write_to' => $asseticWriteTo,
+                    'source_map_source_path_trim' => dirname(__DIR__)
+                ]]
+            ]
+        ]);
+
+        $factory = $this->createMock(AssetFactory::class);
+
+        $collection = new AssetCollection();
+        $collection->setTargetPath('expected.js');
+        $collection->add($this->makeStringAsset(__DIR__ . '/complex', 'asset1.js'));
+        $collection->add(new FileAsset(__DIR__ . '/complex/test.js'));
+        $collection->add(new HttpAsset('https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.js'));
+        $collection = $worker->process($collection, $factory);
+
+        $this->assertEquals(file_get_contents('tests/complex/expected.js'), $collection->dump());
+
+        $sourceMap = $this->loadSourceMap("$asseticWriteTo/expected.js.map");
+        $this->assertEquals($this->loadSourceMap('tests/complex/expected.js.map'), $sourceMap);
+    }
+
+    // uglifyjs can use an input file's source map, if provided inline
+    public function testSourceMapFilterComposedSourceMap()
+    {
+        $asseticWriteTo = sys_get_temp_dir();
+        $worker = new FlattenWorker([
+            [
+                'match' => '/\.js$/',
+                'class' => SourceMapFilter::class,
+                'args' => [[
+                    'site_url' => 'www.coursehero.com/sym-assets',
+                    'assetic_write_to' => $asseticWriteTo,
+                    'source_map_source_path_trim' => dirname(__DIR__)
+                ]]
+            ]
+        ]);
+
+        $factory = $this->createMock(AssetFactory::class);
+
+        $collection = new AssetCollection();
+        $collection->setTargetPath('composed.js');
+        $collection->add($this->makeStringAsset(__DIR__ . '/composed', 'asset1.js'));
+        $collection->add(new FileAsset(dirname(__FILE__) . '/composed/ts.js'));
+        $collection = $worker->process($collection, $factory);
+
+        $this->assertEquals(file_get_contents('tests/composed/expected.js'), $collection->dump());
+
+        $sourceMap = $this->loadSourceMap("$asseticWriteTo/composed.js.map");
+        $this->assertEquals($this->loadSourceMap('tests/composed/expected.js.map'), $sourceMap);
+    }
 
     private function loadSourceMap(string $path)
     {

--- a/tests/SourceMapFilterTest.php
+++ b/tests/SourceMapFilterTest.php
@@ -37,7 +37,7 @@ class SourceMapFilterTest extends TestCase
         $collection->add($this->makeStringAsset(__DIR__ . '/simple', 'asset1.js'));
         $collection->add($this->makeStringAsset(__DIR__ . '/simple', 'asset2.js'));
         $collection->add($this->makeStringAsset(__DIR__ . '/simple', 'asset3.js'));
-        $collection->add($this->makeStringAsset('/../../', 'climb-above-root.js'));
+        $collection->add($this->makeStringAsset('/../..', 'climb-above-root.js'));
         $collection = $worker->process($collection, $factory);
 
         $this->assertEquals(file_get_contents('tests/simple/expected.js'), $collection->dump());

--- a/tests/SourceMapFilterTest.php
+++ b/tests/SourceMapFilterTest.php
@@ -37,6 +37,7 @@ class SourceMapFilterTest extends TestCase
         $collection->add($this->makeStringAsset(__DIR__ . '/simple', 'asset1.js'));
         $collection->add($this->makeStringAsset(__DIR__ . '/simple', 'asset2.js'));
         $collection->add($this->makeStringAsset(__DIR__ . '/simple', 'asset3.js'));
+        $collection->add($this->makeStringAsset('/../../', 'climb-above-root.js'));
         $collection = $worker->process($collection, $factory);
 
         $this->assertEquals(file_get_contents('tests/simple/expected.js'), $collection->dump());
@@ -44,66 +45,66 @@ class SourceMapFilterTest extends TestCase
         $sourceMap = $this->loadSourceMap("$asseticWriteTo/asset.js.map");
         $this->assertEquals($this->loadSourceMap('tests/simple/expected.js.map'), $sourceMap);
     }
-
-    public function testSourceMapFilterComplex()
-    {
-        $asseticWriteTo = sys_get_temp_dir();
-        $worker = new FlattenWorker([
-            [
-                'match' => '/\.js$/',
-                'class' => SourceMapFilter::class,
-                'args' => [[
-                    'site_url' => 'www.coursehero.com/sym-assets',
-                    'assetic_write_to' => $asseticWriteTo,
-                    'source_map_source_path_trim' => dirname(__DIR__)
-                ]]
-            ]
-        ]);
-        
-        $factory = $this->createMock(AssetFactory::class);
-
-        $collection = new AssetCollection();
-        $collection->setTargetPath('expected.js');
-        $collection->add($this->makeStringAsset(__DIR__ . '/complex', 'asset1.js'));
-        $collection->add(new FileAsset(__DIR__ . '/complex/test.js'));
-        $collection->add(new HttpAsset('https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.js'));
-        $collection = $worker->process($collection, $factory);
-
-        $this->assertEquals(file_get_contents('tests/complex/expected.js'), $collection->dump());
-        
-        $sourceMap = $this->loadSourceMap("$asseticWriteTo/expected.js.map");
-        $this->assertEquals($this->loadSourceMap('tests/complex/expected.js.map'), $sourceMap);
-    }
-
-    // uglifyjs can use an input file's source map, if provided inline
-    public function testSourceMapFilterComposedSourceMap()
-    {
-        $asseticWriteTo = sys_get_temp_dir();
-        $worker = new FlattenWorker([
-            [
-                'match' => '/\.js$/',
-                'class' => SourceMapFilter::class,
-                'args' => [[
-                    'site_url' => 'www.coursehero.com/sym-assets',
-                    'assetic_write_to' => $asseticWriteTo,
-                    'source_map_source_path_trim' => dirname(__DIR__)
-                ]]
-            ]
-        ]);
-        
-        $factory = $this->createMock(AssetFactory::class);
-
-        $collection = new AssetCollection();
-        $collection->setTargetPath('composed.js');
-        $collection->add($this->makeStringAsset(__DIR__ . '/composed', 'asset1.js'));
-        $collection->add(new FileAsset(dirname(__FILE__) . '/composed/ts.js'));
-        $collection = $worker->process($collection, $factory);
-
-        $this->assertEquals(file_get_contents('tests/composed/expected.js'), $collection->dump());
-        
-        $sourceMap = $this->loadSourceMap("$asseticWriteTo/composed.js.map");
-        $this->assertEquals($this->loadSourceMap('tests/composed/expected.js.map'), $sourceMap);
-    }
+//
+//    public function testSourceMapFilterComplex()
+//    {
+//        $asseticWriteTo = sys_get_temp_dir();
+//        $worker = new FlattenWorker([
+//            [
+//                'match' => '/\.js$/',
+//                'class' => SourceMapFilter::class,
+//                'args' => [[
+//                    'site_url' => 'www.coursehero.com/sym-assets',
+//                    'assetic_write_to' => $asseticWriteTo,
+//                    'source_map_source_path_trim' => dirname(__DIR__)
+//                ]]
+//            ]
+//        ]);
+//
+//        $factory = $this->createMock(AssetFactory::class);
+//
+//        $collection = new AssetCollection();
+//        $collection->setTargetPath('expected.js');
+//        $collection->add($this->makeStringAsset(__DIR__ . '/complex', 'asset1.js'));
+//        $collection->add(new FileAsset(__DIR__ . '/complex/test.js'));
+//        $collection->add(new HttpAsset('https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.js'));
+//        $collection = $worker->process($collection, $factory);
+//
+//        $this->assertEquals(file_get_contents('tests/complex/expected.js'), $collection->dump());
+//
+//        $sourceMap = $this->loadSourceMap("$asseticWriteTo/expected.js.map");
+//        $this->assertEquals($this->loadSourceMap('tests/complex/expected.js.map'), $sourceMap);
+//    }
+//
+//    // uglifyjs can use an input file's source map, if provided inline
+//    public function testSourceMapFilterComposedSourceMap()
+//    {
+//        $asseticWriteTo = sys_get_temp_dir();
+//        $worker = new FlattenWorker([
+//            [
+//                'match' => '/\.js$/',
+//                'class' => SourceMapFilter::class,
+//                'args' => [[
+//                    'site_url' => 'www.coursehero.com/sym-assets',
+//                    'assetic_write_to' => $asseticWriteTo,
+//                    'source_map_source_path_trim' => dirname(__DIR__)
+//                ]]
+//            ]
+//        ]);
+//
+//        $factory = $this->createMock(AssetFactory::class);
+//
+//        $collection = new AssetCollection();
+//        $collection->setTargetPath('composed.js');
+//        $collection->add($this->makeStringAsset(__DIR__ . '/composed', 'asset1.js'));
+//        $collection->add(new FileAsset(dirname(__FILE__) . '/composed/ts.js'));
+//        $collection = $worker->process($collection, $factory);
+//
+//        $this->assertEquals(file_get_contents('tests/composed/expected.js'), $collection->dump());
+//
+//        $sourceMap = $this->loadSourceMap("$asseticWriteTo/composed.js.map");
+//        $this->assertEquals($this->loadSourceMap('tests/composed/expected.js.map'), $sourceMap);
+//    }
 
     private function loadSourceMap(string $path)
     {

--- a/tests/simple/expected.js
+++ b/tests/simple/expected.js
@@ -1,2 +1,2 @@
-console.log("string asset for asset1.js");console.log("string asset for asset2.js");console.log("string asset for asset3.js");
+console.log("string asset for asset1.js");console.log("string asset for asset2.js");console.log("string asset for asset3.js");console.log("string asset for climb-above-root.js");
 //# sourceMappingURL=www.coursehero.com/sym-assets/asset.js.map

--- a/tests/simple/expected.js.map
+++ b/tests/simple/expected.js.map
@@ -3,7 +3,8 @@
   "sources": [
     "tests/simple/asset1.js",
     "tests/simple/asset2.js",
-    "tests/simple/asset3.js"
+    "tests/simple/asset3.js",
+    "../../climb-above-root.js"
   ],
   "names": [
     "console",

--- a/tests/simple/expected.js.map
+++ b/tests/simple/expected.js.map
@@ -9,12 +9,13 @@
     "console",
     "log"
   ],
-  "mappings": "AAAAA,QAAQC,IAAI,8BCAZD,QAAQC,IAAI,8BCAZD,QAAQC,IAAI",
+  "mappings": "AAAAA,QAAQC,IAAI,8BCAZD,QAAQC,IAAI,8BCAZD,QAAQC,IAAI,8BCAZD,QAAQC,IAAI",
   "file": "asset.js",
   "sourceRoot": "sources:///",
   "sourcesContent": [
     "console.log('string asset for asset1.js');",
     "console.log('string asset for asset2.js');",
-    "console.log('string asset for asset3.js');"
+    "console.log('string asset for asset3.js');",
+    "console.log('string asset for climb-above-root.js');"
   ]
 }


### PR DESCRIPTION
Packages can produce invalid relative paths for source maps. Don't error out when this happens, but rather exclude them from the dump.

This is from including the popper.js package:

```
        "js/../../src/utils/debounce.js?",
        "js/../../src/utils/isBrowser.js?",
        "js/../../src/utils/isFunction.js?",
        "js/../../src/utils/getStyleComputedProperty.js?",
        "js/../../src/utils/getParentNode.js?",
        "js/../../src/utils/getScrollParent.js?",
        "js/../../src/utils/isIE.js?",
        "js/../../src/utils/getOffsetParent.js?",
        "js/../../src/utils/getRoot.js?",
        "js/../../src/utils/findCommonOffsetParent.js?",
        "js/../../src/utils/isOffsetContainer.js?",
        "js/../../src/utils/getScroll.js?",
        "js/../../src/utils/getBordersSize.js?",
        "js/../../src/utils/getWindowSizes.js?",
        "js/../../src/utils/getClientRect.js?",
        "js/../../src/utils/getBoundingClientRect.js?",
```

I believe it's related to https://github.com/FezVrasta/popper.js/issues/785, which has been fixed in master but not published yet. However, I don't believe we should error because of issues like this.